### PR TITLE
style: cargo fmt (unified CI prep)

### DIFF
--- a/src/cli/basic.rs
+++ b/src/cli/basic.rs
@@ -197,7 +197,10 @@ fn sample_dataset(
     indices.shuffle(rng);
 
     if rows_needed > available {
-        let extra: Vec<usize> = (0..available).cycle().take(rows_needed - available).collect();
+        let extra: Vec<usize> = (0..available)
+            .cycle()
+            .take(rows_needed - available)
+            .collect();
         indices.extend(extra);
     }
     indices.truncate(rows_needed);
@@ -243,9 +246,17 @@ pub(crate) fn cmd_mix(
     }
 
     let total_available: usize = datasets.iter().map(|(d, _, _)| d.len()).sum();
-    let target_rows = if max_rows > 0 { max_rows } else { total_available };
+    let target_rows = if max_rows > 0 {
+        max_rows
+    } else {
+        total_available
+    };
 
-    println!("\nMixing {} datasets → {} target rows", datasets.len(), target_rows);
+    println!(
+        "\nMixing {} datasets → {} target rows",
+        datasets.len(),
+        target_rows
+    );
 
     let mut rng = StdRng::seed_from_u64(seed);
     let mut all_batches = Vec::new();
@@ -344,16 +355,20 @@ pub(crate) fn cmd_dedup(
     save_dataset(&deduped, output)?;
 
     let removed = original_rows - deduped_rows;
-    println!("Dedup: {} → {} rows ({} duplicates removed, {:.1}% reduction)",
-        original_rows, deduped_rows, removed,
-        removed as f64 / original_rows.max(1) as f64 * 100.0);
+    println!(
+        "Dedup: {} → {} rows ({} duplicates removed, {:.1}% reduction)",
+        original_rows,
+        deduped_rows,
+        removed,
+        removed as f64 / original_rows.max(1) as f64 * 100.0
+    );
     Ok(())
 }
 
 /// Auto-detect text column and create Unique transform for it.
 fn detect_text_column_dedup(dataset: &ArrowDataset) -> crate::transform::Unique {
-    use arrow::datatypes::DataType;
     use crate::transform::Unique;
+    use arrow::datatypes::DataType;
 
     let schema = dataset.schema();
     for name in &["text", "content", "code", "source"] {
@@ -400,11 +415,17 @@ pub(crate) fn cmd_filter_text(
     save_dataset(&filtered, output)?;
 
     let removed = original_rows - kept;
-    println!("Filter: {} → {} rows ({} removed, {:.1}% kept)",
-        original_rows, kept, removed,
-        kept as f64 / original_rows.max(1) as f64 * 100.0);
-    println!("  min_score={:.2} min_len={} max_len={} column='{}'",
-        min_score, min_length, max_length, col_name);
+    println!(
+        "Filter: {} → {} rows ({} removed, {:.1}% kept)",
+        original_rows,
+        kept,
+        removed,
+        kept as f64 / original_rows.max(1) as f64 * 100.0
+    );
+    println!(
+        "  min_score={:.2} min_len={} max_len={} column='{}'",
+        min_score, min_length, max_length, col_name
+    );
     Ok(())
 }
 
@@ -453,11 +474,13 @@ impl crate::transform::Transform for TextQualityFilter {
         use arrow::compute::filter_record_batch;
 
         let schema = batch.schema();
-        let col_idx = schema.column_with_name(&self.column)
+        let col_idx = schema
+            .column_with_name(&self.column)
             .map(|(i, _)| i)
             .ok_or_else(|| crate::Error::column_not_found(&self.column))?;
 
-        let text_arr = batch.column(col_idx)
+        let text_arr = batch
+            .column(col_idx)
             .as_any()
             .downcast_ref::<StringArray>()
             .ok_or_else(|| crate::Error::column_not_found(&self.column))?;
@@ -468,7 +491,12 @@ impl crate::transform::Transform for TextQualityFilter {
                     Some(false)
                 } else {
                     let text = text_arr.value(i);
-                    Some(passes_quality(text, self.min_score, self.min_length, self.max_length))
+                    Some(passes_quality(
+                        text,
+                        self.min_score,
+                        self.min_length,
+                        self.max_length,
+                    ))
                 }
             })
             .collect();
@@ -497,44 +525,64 @@ fn composite_score(text: &str) -> f64 {
 
 /// Alphanumeric character ratio. Below 0.3 = likely binary/garbage.
 fn score_alnum_ratio(text: &str) -> f64 {
-    if text.is_empty() { return 0.0; }
+    if text.is_empty() {
+        return 0.0;
+    }
     let alnum = text.chars().filter(|c| c.is_alphanumeric()).count();
     let ratio = alnum as f64 / text.len() as f64;
-    if ratio < 0.2 { 0.0 }
-    else if ratio < 0.3 { ratio }
-    else { 1.0 }
+    if ratio < 0.2 {
+        0.0
+    } else if ratio < 0.3 {
+        ratio
+    } else {
+        1.0
+    }
 }
 
 /// Average line length score. Ideal 30-80 chars.
 fn score_line_length(text: &str) -> f64 {
     let lines: Vec<&str> = text.lines().collect();
-    if lines.is_empty() { return 0.0; }
+    if lines.is_empty() {
+        return 0.0;
+    }
     let avg = text.len() as f64 / lines.len() as f64;
-    if avg < 10.0 { 0.2 }
-    else if avg > 200.0 { 0.5 }
-    else { 1.0 }
+    if avg < 10.0 {
+        0.2
+    } else if avg > 200.0 {
+        0.5
+    } else {
+        1.0
+    }
 }
 
 /// Duplicate line ratio. High = boilerplate.
 fn score_dup_lines(text: &str) -> f64 {
     use std::collections::HashSet;
     let lines: Vec<&str> = text.lines().collect();
-    if lines.len() <= 1 { return 1.0; }
+    if lines.len() <= 1 {
+        return 1.0;
+    }
     let unique: HashSet<&str> = lines.iter().copied().collect();
     let dup_ratio = 1.0 - (unique.len() as f64 / lines.len() as f64);
-    if dup_ratio > 0.5 { 0.2 }
-    else { 1.0 - dup_ratio }
+    if dup_ratio > 0.5 {
+        0.2
+    } else {
+        1.0 - dup_ratio
+    }
 }
 
 /// Character-level Shannon entropy. Low = repetitive, high = random/binary.
 fn score_entropy(text: &str) -> f64 {
-    if text.is_empty() { return 0.0; }
+    if text.is_empty() {
+        return 0.0;
+    }
     let mut counts = [0u32; 256];
     for &b in text.as_bytes() {
         counts[b as usize] += 1;
     }
     let len = text.len() as f64;
-    let entropy: f64 = counts.iter()
+    let entropy: f64 = counts
+        .iter()
         .filter(|&&c| c > 0)
         .map(|&c| {
             let p = c as f64 / len;
@@ -542,9 +590,13 @@ fn score_entropy(text: &str) -> f64 {
         })
         .sum();
     let e = entropy / std::f64::consts::LN_2; // bits
-    if e < 2.0 { 0.2 }
-    else if e > 6.5 { 0.3 }
-    else { 1.0 }
+    if e < 2.0 {
+        0.2
+    } else if e > 6.5 {
+        0.3
+    } else {
+        1.0
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -220,10 +220,26 @@ pub fn run() -> ExitCode {
             format,
             seed,
         } => basic::cmd_fim(&input, &output, &column, rate, &format, seed),
-        Commands::Dedup { input, output, column } =>
-            basic::cmd_dedup(&input, &output, column.as_deref()),
-        Commands::FilterText { input, output, column, min_score, min_length, max_length } =>
-            basic::cmd_filter_text(&input, &output, column.as_deref(), min_score, min_length, max_length),
+        Commands::Dedup {
+            input,
+            output,
+            column,
+        } => basic::cmd_dedup(&input, &output, column.as_deref()),
+        Commands::FilterText {
+            input,
+            output,
+            column,
+            min_score,
+            min_length,
+            max_length,
+        } => basic::cmd_filter_text(
+            &input,
+            &output,
+            column.as_deref(),
+            min_score,
+            min_length,
+            max_length,
+        ),
         Commands::View { path, search } => view::cmd_view(&path, search.as_deref()),
         Commands::Import { source } => match source {
             ImportSource::Local {

--- a/src/imbalance.rs
+++ b/src/imbalance.rs
@@ -505,19 +505,28 @@ fn group_rows_by_label(
     if let Some(arr) = label_array.as_any().downcast_ref::<Int64Array>() {
         for i in 0..n {
             if !arr.is_null(i) {
-                groups.entry(arr.value(i).to_string()).or_default().push(i as u32);
+                groups
+                    .entry(arr.value(i).to_string())
+                    .or_default()
+                    .push(i as u32);
             }
         }
     } else if let Some(arr) = label_array.as_any().downcast_ref::<Int32Array>() {
         for i in 0..n {
             if !arr.is_null(i) {
-                groups.entry(arr.value(i).to_string()).or_default().push(i as u32);
+                groups
+                    .entry(arr.value(i).to_string())
+                    .or_default()
+                    .push(i as u32);
             }
         }
     } else if let Some(arr) = label_array.as_any().downcast_ref::<StringArray>() {
         for i in 0..n {
             if !arr.is_null(i) {
-                groups.entry(arr.value(i).to_string()).or_default().push(i as u32);
+                groups
+                    .entry(arr.value(i).to_string())
+                    .or_default()
+                    .push(i as u32);
             }
         }
     } else {
@@ -580,7 +589,10 @@ pub fn resample(
 
     let batches: Vec<arrow::array::RecordBatch> = dataset.iter().collect();
     let batch = if batches.len() == 1 {
-        batches.into_iter().next().ok_or_else(|| Error::empty_dataset("empty"))?
+        batches
+            .into_iter()
+            .next()
+            .ok_or_else(|| Error::empty_dataset("empty"))?
     } else {
         arrow::compute::concat_batches(&dataset.schema(), &batches).map_err(Error::Arrow)?
     };
@@ -593,7 +605,11 @@ pub fn resample(
             Error::invalid_config(format!("Column '{label_column}' not found in schema"))
         })?;
 
-    let groups = group_rows_by_label(batch.column(col_idx).as_ref(), batch.num_rows(), label_column)?;
+    let groups = group_rows_by_label(
+        batch.column(col_idx).as_ref(),
+        batch.num_rows(),
+        label_column,
+    )?;
 
     if groups.is_empty() {
         return Err(Error::empty_dataset("No valid labels found for resampling"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,16 +118,18 @@ pub use federated::{
     FederatedSplitCoordinator, FederatedSplitStrategy, GlobalSplitReport, NodeSplitInstruction,
     NodeSplitManifest, NodeSummary, SplitQualityIssue,
 };
-pub use imbalance::{
-    ClassDistribution, ImbalanceDetector, ImbalanceMetrics, ImbalanceRecommendation,
-    ImbalanceReport, ImbalanceSeverity, ResampleStrategy, sqrt_inverse_weights,
-};
 #[cfg(feature = "shuffle")]
 pub use imbalance::resample;
+pub use imbalance::{
+    sqrt_inverse_weights, ClassDistribution, ImbalanceDetector, ImbalanceMetrics,
+    ImbalanceRecommendation, ImbalanceReport, ImbalanceSeverity, ResampleStrategy,
+};
 #[cfg(feature = "mmap")]
 pub use mmap::{MmapDataset, MmapDatasetBuilder};
 pub use parallel::{ParallelDataLoader, ParallelDataLoaderBuilder};
-pub use quality::{ColumnQuality, QualityChecker, QualityIssue, QualityProfile, QualityReport, TextColumnStats};
+pub use quality::{
+    ColumnQuality, QualityChecker, QualityIssue, QualityProfile, QualityReport, TextColumnStats,
+};
 pub use sketch::{
     Centroid, DDSketch, DataSketch, DistributedDriftDetector, SketchDriftResult, SketchType,
     TDigest,

--- a/src/quality/checks.rs
+++ b/src/quality/checks.rs
@@ -774,17 +774,15 @@ impl TextColumnStats {
         column: &str,
         preamble_prefix: Option<&str>,
     ) -> crate::Result<Self> {
-        use arrow::array::{Array, StringArray};
         use crate::Dataset;
+        use arrow::array::{Array, StringArray};
 
         let schema = dataset.schema();
         let col_idx = schema
             .fields()
             .iter()
             .position(|f| f.name() == column)
-            .ok_or_else(|| {
-                crate::Error::invalid_config(format!("Column '{column}' not found"))
-            })?;
+            .ok_or_else(|| crate::Error::invalid_config(format!("Column '{column}' not found")))?;
 
         let mut lengths: Vec<usize> = Vec::with_capacity(dataset.len());
         let mut empty_count = 0usize;
@@ -796,9 +794,7 @@ impl TextColumnStats {
                 .as_any()
                 .downcast_ref::<StringArray>()
                 .ok_or_else(|| {
-                    crate::Error::invalid_config(format!(
-                        "Column '{column}' is not a string type"
-                    ))
+                    crate::Error::invalid_config(format!("Column '{column}' is not a string type"))
                 })?;
 
             for i in 0..str_arr.len() {

--- a/src/transform/fim.rs
+++ b/src/transform/fim.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 use arrow::array::{Array, RecordBatch, StringArray};
 use rand::{Rng, SeedableRng};
 
-use crate::error::{Error, Result};
 use super::Transform;
+use crate::error::{Error, Result};
 
 /// FIM format variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -219,16 +219,13 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
 
     fn create_code_batch() -> RecordBatch {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("code", DataType::Utf8, false),
-        ]));
+        let schema = Arc::new(Schema::new(vec![Field::new("code", DataType::Utf8, false)]));
         let code = StringArray::from(vec![
             "def hello():\n    print('hello world')\n",
             "class Foo:\n    def bar(self):\n        return 42\n",
             "x = 1",
         ]);
-        RecordBatch::try_new(schema, vec![Arc::new(code)])
-            .expect("batch creation should succeed")
+        RecordBatch::try_new(schema, vec![Arc::new(code)]).expect("batch creation should succeed")
     }
 
     #[test]
@@ -255,9 +252,7 @@ mod tests {
     #[test]
     fn test_fim_transform_applies_to_batch() {
         let batch = create_code_batch();
-        let fim = Fim::new("code")
-            .with_rate(1.0)
-            .with_seed(42);
+        let fim = Fim::new("code").with_rate(1.0).with_seed(42);
         let result = fim.apply(batch);
         assert!(result.is_ok());
         let result = result.expect("should succeed");
@@ -278,9 +273,7 @@ mod tests {
     #[test]
     fn test_fim_rate_zero_leaves_unchanged() {
         let batch = create_code_batch();
-        let fim = Fim::new("code")
-            .with_rate(0.0)
-            .with_seed(42);
+        let fim = Fim::new("code").with_rate(0.0).with_seed(42);
         let result = fim.apply(batch.clone()).expect("should succeed");
         let original = batch
             .column(0)
@@ -304,8 +297,16 @@ mod tests {
         let fim2 = Fim::new("code").with_rate(1.0).with_seed(123);
         let r1 = fim1.apply(batch.clone()).expect("should succeed");
         let r2 = fim2.apply(batch).expect("should succeed");
-        let c1 = r1.column(0).as_any().downcast_ref::<StringArray>().expect("s");
-        let c2 = r2.column(0).as_any().downcast_ref::<StringArray>().expect("s");
+        let c1 = r1
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("s");
+        let c2 = r2
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("s");
         for i in 0..c1.len() {
             assert_eq!(c1.value(i), c2.value(i));
         }
@@ -361,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_find_char_boundary_multibyte() {
-        let s = "héllo";  // é is 2 bytes
+        let s = "héllo"; // é is 2 bytes
         let boundary = find_char_boundary(s, 2);
         assert!(s.is_char_boundary(boundary));
     }

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -12,19 +12,19 @@ use arrow::{
 
 use crate::error::{Error, Result};
 
+#[cfg(feature = "shuffle")]
+mod fim;
 mod numeric;
 mod row_ops;
 mod selection;
-#[cfg(feature = "shuffle")]
-mod fim;
 
+#[cfg(feature = "shuffle")]
+pub use fim::{Fim, FimFormat, FimTokens};
 pub use numeric::{Cast, FillNull, FillStrategy, NormMethod, Normalize};
 #[cfg(feature = "shuffle")]
 pub use row_ops::{Sample, Shuffle};
 pub use row_ops::{Skip, Sort, SortOrder, Take, Unique};
 pub use selection::{Drop, Rename, Select};
-#[cfg(feature = "shuffle")]
-pub use fim::{Fim, FimFormat, FimTokens};
 
 /// A transform that can be applied to RecordBatches.
 ///


### PR DESCRIPTION
## Summary
- Auto-formatted with `cargo fmt` (Rust 1.93.0)
- Prerequisite for unified CI lint gate deployment
- No functional changes — formatting only

## Context
Part of unified CI pipeline rollout ([spec](https://github.com/paiml/infra/blob/main/docs/specifications/unified-ci-pipeline.md)).
The lint gate requires `cargo fmt --check` to pass.

Generated with [Claude Code](https://claude.com/claude-code)