### PR TITLE
chore: bump version to 0.2.8 (includes decontamination)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alimentar"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 authors = ["paiml"]
 description = "Data Loading, Distribution and Tooling in Pure Rust"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.8 for crates.io publish
- Includes `quality::decontaminate` module (n-gram overlap detection)
- 9 tests pass for decontamination functionality
- Needed by aprender to wire `apr data decontaminate` (GH-11)

## Test plan
- [x] `cargo test --lib -- quality::decontaminate` (9/9 pass)
- [ ] CI gate passes
- [ ] Publish to crates.io after merge

Generated with [Claude Code](https://claude.com/claude-code)